### PR TITLE
sort appoitments by end_timestamp, test on edent prod

### DIFF
--- a/appointments/chalicelib/database.py
+++ b/appointments/chalicelib/database.py
@@ -29,7 +29,10 @@ class DynamoDBAppointments(AppointmentsDB):
     def list_all_items(self, username=DEFAULT_USERNAME):
         logger.info('Listing all patients')
         response = self._table.scan()
-        return response['Items']
+        sorted_reponse = response['Items']
+        for key in sorted_reponse:
+            key['end_timestamp'] = key['end'].replace('-', '').replace(':', '').replace('T', '')
+        return sorted(sorted_reponse, key=lambda x: x['end_timestamp'])
 
     def add_item(self, appointment, username=DEFAULT_USERNAME):
         new_appointment = make_appointment(appointment, username)


### PR DESCRIPTION
sort appointment on service, not on dynamoDB query because it needs a sort key, then we need to change the  "end" timestamp on the calendar-scheduler because dynamoDB only sorts Scalars, i think this is the quickest solution without changing other services 